### PR TITLE
Optional link in alert

### DIFF
--- a/pyrail/models.py
+++ b/pyrail/models.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import List
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin

--- a/pyrail/models.py
+++ b/pyrail/models.py
@@ -269,9 +269,7 @@ class Alert(DataClassORJSONMixin):
     end_time: datetime = field(
         metadata=field_options(alias="endTime", deserialize=lambda x: timestamp_to_datetime(x))
     )  # End time of the alert
-    link: Optional[str] = field(
-        default_factory=lambda: None
-    )  # Link to more information
+    link: str | None = field(default=None)  # Link to more information
 
 @dataclass
 class Alerts(DataClassORJSONMixin):

--- a/pyrail/models.py
+++ b/pyrail/models.py
@@ -263,14 +263,15 @@ class Alert(DataClassORJSONMixin):
     id: str  # Alert ID
     header: str  # Alert header
     lead: str  # Alert lead
-    link: str  # Link to more information
     start_time: datetime = field(
         metadata=field_options(alias="startTime", deserialize=lambda x: timestamp_to_datetime(x))
     )  # Start time of the alert
     end_time: datetime = field(
         metadata=field_options(alias="endTime", deserialize=lambda x: timestamp_to_datetime(x))
     )  # End time of the alert
-
+    link: Optional[str] = field(
+        default_factory=lambda: None
+    )  # Link to more information
 
 @dataclass
 class Alerts(DataClassORJSONMixin):

--- a/pyrail/models.py
+++ b/pyrail/models.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin


### PR DESCRIPTION
Example

```json
{
  "number": "1",
  "alert": [
    {
      "id": "0",
      "header": "Gembloux - Namur / Namen",
      "description": "During the weekend of 18-19/01 Infrabel is working on the track. The route and departure times of the IC trains Brux.-Midi/Brus.-Zuid - Namur / Namen - Luxembourg (LU) change. This will extend the journey time by 30 minutes. The travel planner takes these changes into account.",
      "lead": "During the weekend of 18-19/01 Infrabel is working on the track",
      "startTime": "1737165600",
      "endTime": "1737327540"
    }
  ]
}
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the Alert class by making the link attribute optional.
- **Refactor**
	- Updated link attribute in Alert class to allow None as a default value. 
	- Maintained required link attribute in Disturbance class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->